### PR TITLE
Changing ansible.leapp to infra.leapp in the Validated Content List

### DIFF
--- a/validated-content-list.md
+++ b/validated-content-list.md
@@ -2,7 +2,6 @@
 
 | Validated Content Collection Name  | Description |
 | ------------- | ------------- |
-| ansible.leapp | Perform RHEL in-place upgrades using the Leapp framework  |
 | cloud.aws_ops | Roles/playbooks to demo Ansible on AWS  |
 | cloud.aws_troubleshooting  | Ansible roles to help troubleshoot AWS Resources  |
 | cloud.azure_ops | Ansible roles and playbook to help automate the management of resources on Microsoft Azure |
@@ -11,6 +10,7 @@
 | infra.ah_configuration | Ansible playbooks to interact with an Ansible Automation Hub or Galaxy NG server  |
 | infra.controller_configuration | Ansible roles to interact with an AWX or Ansible Controller server  |
 | infra.ee_utilities | Roles to manage Ansible Execution Environments  |
+| infra.leapp | Perform RHEL in-place upgrades using the Leapp framework  |
 | infra.osbuild | Collection for management of osbuild composer to build rpm-ostree  |
 | network.base | Core for other validated content; provides the platform agnostic role - Resource Manager  |
 | network.bgp | Manage BGP resources independent of platforms and perform BGP health checks  |


### PR DESCRIPTION
infra.leapp was incorrectly added as ansible.leapp. This has been fixed here. 

See #6 