### PR TITLE
Candidate Sign-Off: infra.openshift_virtualization_migration

### DIFF
--- a/validated-content-list.md
+++ b/validated-content-list.md
@@ -20,6 +20,7 @@
 | infra.leapp | Perform RHEL in-place upgrades using the Leapp framework  |
 | infra.lvm_snapshots | Reliable snapshot/rollback capabilities for enabling RHEL in-place upgrades  |
 | infra.middleware_ocpv | Seamlessly handle the complete lifecycle of Virtual Machines within an OpenShift Virtualization runtime environment  |
+| infra.openshift_virtualization_migration | Migrate VM workloads from existing hypervisors to Red Hat OpenShift Virtualization using Ansible Automation Platform   |
 | infra.osbuild | Collection for management of osbuild composer to build rpm-ostree  |
 | network.acls | Manage acls resources independent of platforms and perform acls health checks |
 | network.base | Core for other validated content; provides the platform agnostic role - Resource Manager  |

--- a/validated-content-list.md
+++ b/validated-content-list.md
@@ -22,6 +22,7 @@
 | infra.middleware_ocpv | Seamlessly handle the complete lifecycle of Virtual Machines within an OpenShift Virtualization runtime environment  |
 | infra.openshift_virtualization_migration | Migrate VM workloads from existing hypervisors to Red Hat OpenShift Virtualization using Ansible Automation Platform   |
 | infra.osbuild | Collection for management of osbuild composer to build rpm-ostree  |
+| infra.openshift_virtualization_ops | Collection for the managing and maintaining VM workloads within Red Hat OpenShift Virtualization |
 | network.acls | Manage acls resources independent of platforms and perform acls health checks |
 | network.base | Core for other validated content; provides the platform agnostic role - Resource Manager  |
 | network.bgp | Manage BGP resources independent of platforms and perform BGP health checks  |


### PR DESCRIPTION
Noticed that https://console.redhat.com/ansible/automation-hub/repo/validated/infra/openshift_virtualization_migration/ is not listed here

<!--If this is a Validated Content Sign-Off PR, then please follow the following requirements: 

- [x] Uses the following name format: `Candidate Sign-Off: <candidate.name>`
- [x] The only contained change is adding the candidate name to the `validated-content-list.md` table -->


<!-- add details as needed below-->